### PR TITLE
Initial tests and option for address+port for client

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -26,3 +26,15 @@ export {
   yellow,
   green
 } from "https://deno.land/std@v0.32.0/fmt/colors.ts";
+
+// Tests
+
+export {
+  runTests,
+  test
+} from "https://deno.land/std@v0.32.0/testing/mod.ts";
+
+export {
+  assertEquals,
+  assert,
+} from "https://deno.land/std@v0.32.0/testing/asserts.ts";

--- a/example_app/console_app/client.ts
+++ b/example_app/console_app/client.ts
@@ -1,7 +1,7 @@
 import { SocketClient } from "../../mod.ts";
 import { green } from "../../deps.ts";
 
-const ioClient = new SocketClient;
+const ioClient = new SocketClient({ port: 3000 });
 ioClient.initConsole('chatroom1');
 const io = await ioClient.attach();
 

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -74,9 +74,20 @@ class Socket {
 
 export default class SocketClient {
   public socket: any;
+  private options: any;
+  constructor(options: any = {}) {
+    this.options = {
+      address: options.address || "127.0.0.1",
+      port: options.port || 3000,
+    };
+  }
+
+  public getOptions() {
+    return this.options;
+  }
 
   public async attach() {
-    const socketConnection = await connectWebSocket("ws://127.0.0.1:3000");
+    const socketConnection = await connectWebSocket(`ws://${this.options.port}:${this.options.port}`);
     this.socket = new Socket(socketConnection);
     return this.socket;
   }

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -87,7 +87,7 @@ export default class SocketClient {
   }
 
   public async attach() {
-    const socketConnection = await connectWebSocket(`ws://${this.options.port}:${this.options.port}`);
+    const socketConnection = await connectWebSocket(`ws://${this.options.address}:${this.options.port}`);
     this.socket = new Socket(socketConnection);
     return this.socket;
   }

--- a/src/server/event_emitter.ts
+++ b/src/server/event_emitter.ts
@@ -21,7 +21,7 @@ class Sender {
     }
   }
 
-  public async send() {
+  private async send() {
     if (this.ready && this.messageQueue.length) {
       this.ready = false;
       const messageObj = this.messageQueue.shift();
@@ -50,8 +50,6 @@ class Sender {
   }
 }
 
-export type IncomingMessageTypes = Uint8Array | String;
-
 export default class EventEmitter {
   private events: Object;
   private clients: Object;
@@ -63,6 +61,14 @@ export default class EventEmitter {
     this.sender = new Sender();
   }
 
+  public getClients() {
+    return this.clients;
+  }
+
+  public getEvents() {
+    return this.events;
+  }
+
   private addEvent(type: string, cb: any) {
     if (!this.events[type]) {
       this.events[type] = { listeners: new Map(), callbacks: [] };
@@ -71,7 +77,7 @@ export default class EventEmitter {
     this.events[type].callbacks.push(cb);
   }
 
-  private addListener(type: string, clientId: any) {
+  public addListener(type: string, clientId: any) {
     if (!this.events[type]) {
       this.events[type] = { listeners: new Map(), callbacks: [] };
     }

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -1,0 +1,18 @@
+Deno.env().DRASH_PROCESS = "test";
+
+import { runTests } from "../deps.ts";
+export {
+  test,
+  runTests,
+  assertEquals,
+  assert,
+} from "../deps.ts";
+
+// Server
+import "./unit/server/event_emitter_test.ts";
+
+// Client
+import "./unit/client/client_test.ts";
+
+
+runTests();

--- a/tests/unit/client/client_test.ts
+++ b/tests/unit/client/client_test.ts
@@ -1,0 +1,40 @@
+import SocketClient from "../../../src/client/client.ts";
+import { test, assertEquals, assert } from "../../test.ts";
+
+test("should connect to 3000 if port is not provided", () => {
+  const expect = 3000;
+  const client = new SocketClient();
+  const clientOptions = client.getOptions();
+  assertEquals(clientOptions.port, expect);
+});
+
+test("should connect to provided port", () => {
+  const expect = 3333;
+  const client = new SocketClient({ port: 3333 });
+  const clientOptions = client.getOptions();
+  assertEquals(clientOptions.port, expect);
+});
+
+test("should connect to 127.0.0.1 if address is not provided", () => {
+  const expect = "127.0.0.1";
+  const client = new SocketClient({ port: 3333 });
+  const clientOptions = client.getOptions();
+  assertEquals(clientOptions.address, expect);
+});
+
+test("should connect to provided address", () => {
+  const expect = "1.1.1.1";
+  const client = new SocketClient({ address: "1.1.1.1", port: 3333 });
+  const clientOptions = client.getOptions();
+  assertEquals(clientOptions.address, expect);
+});
+
+test("should connect to provided address and port", () => {
+  const expect = { address:"1.1.1.1", port: 1111 };
+  const client = new SocketClient({
+    address:"1.1.1.1",
+    port: 1111,
+  });
+  const clientOptions = client.getOptions();
+  assertEquals(clientOptions, expect);
+});

--- a/tests/unit/server/event_emitter_test.ts
+++ b/tests/unit/server/event_emitter_test.ts
@@ -1,0 +1,76 @@
+import EventEmitter from "../../../src/server/event_emitter.ts";
+import { test, assertEquals, assert } from "../../test.ts";
+
+let io = new EventEmitter();
+
+const ClientSocket = () => {
+  return {
+    send: () => true,
+    close: () => true,
+  }
+};
+
+test("should have Events, Clients, and Sender on class init", () => {
+  const expect = ['events', 'clients', 'sender'];
+  assert(expect.every((val) => io[val]));
+});
+
+test("should connect a client", () => {
+  const clientId = 1;
+  const clientSocket = ClientSocket();
+  io.addClient(clientSocket, clientId);
+  const connectedClients = io.getClients();
+  assertEquals(connectedClients[clientId].socket, clientSocket);
+});
+
+test("should remove client", async () => {
+  const clientId = 1;
+  const clientSocket = ClientSocket();
+  await io.removeClient(clientId);
+  const connectedClients = io.getClients();
+  assertEquals(connectedClients, []);
+
+  const newClientId = 2;
+  io.addClient(clientSocket, newClientId);
+  assertEquals(connectedClients[newClientId].socket, clientSocket);
+});
+
+test("should add events for server to listen to", () => {
+  const expect = ['chat', 'room'];
+  io.on('chat', () => true);
+  io.on('room', () => true);
+
+  const events = io.getEvents();
+  assert(expect.every((val) => events[val]));
+});
+
+test("should detect same event name and push cb into callbacks array of event", () => {
+  const expect = ['chat', 'room'];
+  io.on('chat', () => true);
+
+  const events = io.getEvents();
+  assert(expect.every((val) => events[val]));
+  assertEquals(Object.keys(events).length, expect.length);
+  assertEquals(events['chat'].callbacks.length, 2);
+});
+
+test("should register which clients are listening to what event", () => {
+  const expect = ['chat', 'room'];
+  io.addListener('chat', 2);
+  const events = io.getEvents();
+  assert(events['chat'].listeners.has(2));
+  
+  const newClientId = 3;
+  const clientSocket = ClientSocket();
+  io.addClient(clientSocket, newClientId);
+  io.addListener('chat', newClientId);
+  assertEquals(events['chat'].listeners.size, 2);
+});
+
+test("should remove client from events[type].listeners", async () => {
+  await io.removeClient(2);
+  const clientsConnected = io.getClients();
+  const events = io.getEvents();
+  assert(!clientsConnected[2])
+  assertEquals(events['chat'].listeners.size, 1);
+});


### PR DESCRIPTION
## What's new
- Initial unit tests created
- Ability to add custom address and port for client

## Next steps
- Add additional tests (especially for server.ts). Did not want to bloat this PR and wanted to get initial tests out asap.
- Upgrade to deno v0.34.0
- Think about more options/config for client and server classes (i.e. redis, ping intervals, ping timeouts, path, etc)
- broadcast method