### PR TITLE
Reserved event types and server tests

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -21,7 +21,6 @@ export {
 } from "https://deno.land/std@v0.32.0/textproto/mod.ts";
 
 export {
-  blue,
   green
 } from "https://deno.land/std@v0.32.0/fmt/colors.ts";
 
@@ -35,5 +34,4 @@ export {
 export {
   assertEquals,
   assert,
-  assertThrows,
 } from "https://deno.land/std@v0.32.0/testing/asserts.ts";

--- a/deps.ts
+++ b/deps.ts
@@ -1,6 +1,6 @@
 export {
   serve
-} from "https://deno.land/std@v0.32.0/http/server.ts";
+} from "https://deno.land/std@v0.34.0/http/server.ts";
 
 export {
   connectWebSocket,
@@ -10,28 +10,23 @@ export {
   acceptWebSocket,
   WebSocket,
   append
-} from "https://deno.land/std@v0.32.0/ws/mod.ts";
+} from "https://deno.land/std@v0.34.0/ws/mod.ts";
 
 export {
   BufReader
-} from "https://deno.land/std@v0.32.0/io/bufio.ts";
+} from "https://deno.land/std@v0.34.0/io/bufio.ts";
 
 export {
   TextProtoReader
-} from "https://deno.land/std@v0.32.0/textproto/mod.ts";
+} from "https://deno.land/std@v0.34.0/textproto/mod.ts";
 
 export {
   green
-} from "https://deno.land/std@v0.32.0/fmt/colors.ts";
+} from "https://deno.land/std@v0.34.0/fmt/colors.ts";
 
 // Tests
 
 export {
-  runTests,
-  test
-} from "https://deno.land/std@v0.32.0/testing/mod.ts";
-
-export {
   assertEquals,
   assert,
-} from "https://deno.land/std@v0.32.0/testing/asserts.ts";
+} from "https://deno.land/std@v0.34.0/testing/asserts.ts";

--- a/deps.ts
+++ b/deps.ts
@@ -37,4 +37,5 @@ export {
 export {
   assertEquals,
   assert,
+  assertThrows,
 } from "https://deno.land/std@v0.32.0/testing/asserts.ts";

--- a/deps.ts
+++ b/deps.ts
@@ -22,8 +22,6 @@ export {
 
 export {
   blue,
-  red,
-  yellow,
   green
 } from "https://deno.land/std@v0.32.0/fmt/colors.ts";
 

--- a/deps.ts
+++ b/deps.ts
@@ -1,6 +1,6 @@
 export {
   serve
-} from "https://deno.land/std@v0.34.0/http/server.ts";
+} from "https://deno.land/std@v0.35.0/http/server.ts";
 
 export {
   connectWebSocket,
@@ -10,23 +10,23 @@ export {
   acceptWebSocket,
   WebSocket,
   append
-} from "https://deno.land/std@v0.34.0/ws/mod.ts";
+} from "https://deno.land/std@v0.35.0/ws/mod.ts";
 
 export {
   BufReader
-} from "https://deno.land/std@v0.34.0/io/bufio.ts";
+} from "https://deno.land/std@v0.35.0/io/bufio.ts";
 
 export {
   TextProtoReader
-} from "https://deno.land/std@v0.34.0/textproto/mod.ts";
+} from "https://deno.land/std@v0.35.0/textproto/mod.ts";
 
 export {
   green
-} from "https://deno.land/std@v0.34.0/fmt/colors.ts";
+} from "https://deno.land/std@v0.35.0/fmt/colors.ts";
 
 // Tests
 
 export {
   assertEquals,
   assert,
-} from "https://deno.land/std@v0.34.0/testing/asserts.ts";
+} from "https://deno.land/std@v0.35.0/testing/asserts.ts";

--- a/example_app/console_app/client.ts
+++ b/example_app/console_app/client.ts
@@ -5,6 +5,6 @@ const ioClient = new SocketClient({ port: 3000 });
 ioClient.initConsole('chatroom1');
 const io = await ioClient.attach();
 
-io.on('chatroom1', (incomingMessage) => {
+io.on('chatroom1', (incomingMessage: any) => {
   console.log(green(`Incoming message: ${incomingMessage}`));
 });

--- a/example_app/console_app/server.ts
+++ b/example_app/console_app/server.ts
@@ -6,7 +6,7 @@ io.on('connection', () => {
   console.log('A user connected.');
 });
 
-io.on('chatroom1', function (incomingMessage) {
+io.on('chatroom1', function (incomingMessage: any) {
   io.to('chatroom1', incomingMessage);
 });
 

--- a/example_app/console_app/server.ts
+++ b/example_app/console_app/server.ts
@@ -2,6 +2,10 @@ import { SocketServer } from "../../mod.ts";
 
 const io = new SocketServer();
 
+io.on('connection', () => {
+  console.log('User Connected');
+});
+
 io.on('chatroom1', function (incomingMessage) {
   io.to('chatroom1', incomingMessage);
 });

--- a/example_app/console_app/server.ts
+++ b/example_app/console_app/server.ts
@@ -3,9 +3,13 @@ import { SocketServer } from "../../mod.ts";
 const io = new SocketServer();
 
 io.on('connection', () => {
-  console.log('User Connected');
+  console.log('A user connected.');
 });
 
 io.on('chatroom1', function (incomingMessage) {
   io.to('chatroom1', incomingMessage);
+});
+
+io.on('disconnect', () => {
+  console.log('A user disconnected.');
 });

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -11,7 +11,7 @@ export default class SocketClient {
   constructor(options: any = {}) {
     this.options = {
       address: options.address || "127.0.0.1",
-      port: options.port || 3000,
+      port: options.port || "3000",
     };
   }
 

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -1,76 +1,9 @@
-import { MESSAGE_TYPE } from "../lib/io_types.ts";
+import Socket from "./socket.ts";
 import {
   connectWebSocket,
-  append,
   TextProtoReader,
   BufReader
 } from "../../deps.ts";
-
-class Socket {
-  protected socket: any;
-  protected listening: any;
-  protected messageQueue: any;
-  protected ready: any;
-
-  constructor(socket) {
-    this.socket = socket;
-    this.listening = {};
-    this.messageQueue = [];
-    this.ready = true;
-    this.init();
-  }
-
-  private async init() {
-    for await (const msg of this.socket.receive()) {
-      if (typeof msg === "string") {
-      } else if (msg instanceof Uint8Array) {
-        this.receiveEncodedMessage(msg);
-      }
-    }
-  }
-
-  private receiveEncodedMessage(encodedMessage: MESSAGE_TYPE) {
-    const decodedMessage = new TextDecoder().decode(encodedMessage);
-    const parsedMessage = JSON.parse(decodedMessage);
-    Object.keys(parsedMessage).forEach((type) => {
-      if (this.listening[type]) this.listening[type](parsedMessage[type]);
-    })
-  }
-
-  public on(type: string, cb: Function) {
-    if (!this.listening[type]) this.listening[type] = null;
-    this.listening[type] = cb;
-    const toSend = JSON.stringify({ listeningTo: type });
-    const encoded = new TextEncoder().encode(toSend);
-    this.messageQueue.push(encoded);
-    this.emit();
-  }
-
-  public send(type: string, message: string) {
-    let toSend = null;
-    if (type) {
-      const preparedString = JSON.stringify({ [type]: message });
-      toSend = new TextEncoder().encode(preparedString);
-    } else {
-      toSend = message;
-    }
-    this.messageQueue.push(toSend);
-    this.emit();
-  }
-
-  private async emit() {
-    if (this.ready && this.messageQueue.length) {
-      this.ready = false;
-      let toSend = new Uint8Array(0);
-      while (this.messageQueue.length) {
-        toSend = append(toSend, this.messageQueue.shift());
-      }
-      await this.socket.send(toSend);
-      this.ready = true;
-      this.emit();
-    }
-  }
-}
 
 export default class SocketClient {
   public socket: any;

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -87,7 +87,7 @@ export default class SocketClient {
   }
 
   public async attach() {
-    const socketConnection = await connectWebSocket(`ws://${this.options.port}:${this.options.port}`);
+    const socketConnection = await connectWebSocket(`ws://${this.options.address}:${this.options.port}`);
     this.socket = new Socket(socketConnection);
     return this.socket;
   }

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -1,4 +1,4 @@
-import { MessasgeType } from "../lib/io_types.ts";
+import { MESSAGE_TYPE } from "../lib/io_types.ts";
 import {
   connectWebSocket,
   append,
@@ -29,7 +29,7 @@ class Socket {
     }
   }
 
-  private receiveEncodedMessage(encodedMessage: MessasgeType) {
+  private receiveEncodedMessage(encodedMessage: MESSAGE_TYPE) {
     const decodedMessage = new TextDecoder().decode(encodedMessage);
     const parsedMessage = JSON.parse(decodedMessage);
     Object.keys(parsedMessage).forEach((type) => {
@@ -40,7 +40,7 @@ class Socket {
   public on(type: string, cb: Function) {
     if (!this.listening[type]) this.listening[type] = null;
     this.listening[type] = cb;
-    const toSend = JSON.stringify({ eventType: type });
+    const toSend = JSON.stringify({ listeningTo: type });
     const encoded = new TextEncoder().encode(toSend);
     this.messageQueue.push(encoded);
     this.emit();

--- a/src/client/socket.ts
+++ b/src/client/socket.ts
@@ -7,7 +7,7 @@ export default class Socket {
   protected messageQueue: any;
   protected ready: any;
 
-  constructor(socket) {
+  constructor(socket: any) {
     this.socket = socket;
     this.listening = {};
     this.messageQueue = [];

--- a/src/client/socket.ts
+++ b/src/client/socket.ts
@@ -1,0 +1,68 @@
+import { append } from "../../deps.ts";
+import { MESSAGE_TYPE } from "../lib/io_types.ts";
+
+export default class Socket {
+  protected socket: any;
+  protected listening: any;
+  protected messageQueue: any;
+  protected ready: any;
+
+  constructor(socket) {
+    this.socket = socket;
+    this.listening = {};
+    this.messageQueue = [];
+    this.ready = true;
+    this.init();
+  }
+
+  private async init() {
+    for await (const msg of this.socket.receive()) {
+      if (typeof msg === "string") {
+      } else if (msg instanceof Uint8Array) {
+        this.receiveEncodedMessage(msg);
+      }
+    }
+  }
+
+  private receiveEncodedMessage(encodedMessage: MESSAGE_TYPE) {
+    const decodedMessage = new TextDecoder().decode(encodedMessage);
+    const parsedMessage = JSON.parse(decodedMessage);
+    Object.keys(parsedMessage).forEach((type) => {
+      if (this.listening[type]) this.listening[type](parsedMessage[type]);
+    })
+  }
+
+  public on(type: string, cb: Function) {
+    if (!this.listening[type]) this.listening[type] = null;
+    this.listening[type] = cb;
+    const toSend = JSON.stringify({ listeningTo: type });
+    const encoded = new TextEncoder().encode(toSend);
+    this.messageQueue.push(encoded);
+    this.emit();
+  }
+
+  public send(type: string, message: string) {
+    let toSend = null;
+    if (type) {
+      const preparedString = JSON.stringify({ [type]: message });
+      toSend = new TextEncoder().encode(preparedString);
+    } else {
+      toSend = message;
+    }
+    this.messageQueue.push(toSend);
+    this.emit();
+  }
+
+  private async emit() {
+    if (this.ready && this.messageQueue.length) {
+      this.ready = false;
+      let toSend = new Uint8Array(0);
+      while (this.messageQueue.length) {
+        toSend = append(toSend, this.messageQueue.shift());
+      }
+      await this.socket.send(toSend);
+      this.ready = true;
+      this.emit();
+    }
+  }
+}

--- a/src/lib/io_types.ts
+++ b/src/lib/io_types.ts
@@ -1,5 +1,5 @@
-type MessasgeType = Uint8Array;
+type MESSAGE_TYPE = Uint8Array;
 
 export {
-  MessasgeType,
+  MESSAGE_TYPE,
 }

--- a/src/lib/reserved_event_types.ts
+++ b/src/lib/reserved_event_types.ts
@@ -1,0 +1,9 @@
+const RESERVED_EVENTS = [
+  'connection',
+  'disconnect',
+  'listeningTo'
+];
+
+export {
+  RESERVED_EVENTS,
+}

--- a/src/lib/reserved_event_types.ts
+++ b/src/lib/reserved_event_types.ts
@@ -1,9 +1,9 @@
-const RESERVED_EVENTS = [
+const RESERVED_EVENT_TYPES = [
   'connection',
   'disconnect',
   'listeningTo'
 ];
 
 export {
-  RESERVED_EVENTS,
+  RESERVED_EVENT_TYPES,
 }

--- a/src/server/event_emitter.ts
+++ b/src/server/event_emitter.ts
@@ -1,4 +1,5 @@
-import { MessasgeType } from "../lib/io_types.ts";
+import { MESSAGE_TYPE } from "../lib/io_types.ts";
+import { RESERVED_EVENTS } from "../lib/reserved_event_types.ts"
 
 class Sender {
   private messageQueue: any;
@@ -109,6 +110,9 @@ export default class EventEmitter {
   }
 
   public on(type: string, cb: Function) {
+    if (RESERVED_EVENTS.includes(type)) {
+      throw new Error(`${RESERVED_EVENTS} are reserved event types.`);
+    }
     this.addEvent(type, cb);
   }
 
@@ -130,7 +134,7 @@ export default class EventEmitter {
     this.sender.add(msg);
   }
 
-  public async checkEvent(message: MessasgeType, clientId: number) {
+  public async checkEvent(message: MESSAGE_TYPE, clientId: number) {
     let result = new TextDecoder().decode(message);
     let parseMessage = {};
     try {
@@ -140,7 +144,7 @@ export default class EventEmitter {
     }
 
     for await (let type of Object.keys(parseMessage)) {
-      if (type === 'eventType') {
+      if (type === 'listeningTo') {
         this.addListener(parseMessage[type], clientId);
       } else if (this.events[type]) {
         await this.sender.invokeCallback({

--- a/src/server/event_emitter.ts
+++ b/src/server/event_emitter.ts
@@ -1,55 +1,6 @@
+import Sender from "./sender.ts";
 import { MESSAGE_TYPE } from "../lib/io_types.ts";
-import { RESERVED_EVENTS } from "../lib/reserved_event_types.ts"
-
-class Sender {
-  private messageQueue: any;
-  private ready: boolean;
-
-  constructor() {
-    this.messageQueue = [];
-    this.ready = true;
-  }
-
-  public add(message: any) {
-    this.messageQueue.push(message);
-    this.send();
-  }
-
-  public async invokeCallback(msgObj: any): Promise<void> {
-    const args = Array.prototype.slice.call(arguments);
-    for await (let cb of msgObj.callbacks) {
-      cb.apply(this, args);
-    }
-  }
-
-  private async send() {
-    if (this.ready && this.messageQueue.length) {
-      this.ready = false;
-      const messageObj = this.messageQueue.shift();
-      const {
-        type,
-        message,
-        from,
-        listeners
-      } = messageObj;
-      console.log(message);
-
-      const encodedMessage = new TextEncoder().encode(JSON.stringify({ [type]: message }));
-      for await (let listener of listeners) {
-        const [clientId, socketConn] = listener;
-        if (clientId !== from) {
-          try {
-            await socketConn.send(encodedMessage);
-          } catch (err) {
-            console.log(`Unable to send to client: ${clientId}`);
-          }
-        }
-      }
-      this.ready = true;
-      this.send();
-    }
-  }
-}
+import { RESERVED_EVENTS } from "../lib/reserved_event_types.ts";
 
 export default class EventEmitter {
   private events: Object;
@@ -156,9 +107,6 @@ export default class EventEmitter {
       }
     }
   }
-
-  // to do
-  // public async broadcast() {}
 
   public send(type: string, message: string) {
     this._addToMessageQueue(type, message);

--- a/src/server/event_emitter.ts
+++ b/src/server/event_emitter.ts
@@ -42,7 +42,8 @@ export default class EventEmitter {
 
   private handleReservedEventTypes(type: string, clientId: number) {
     switch(type) {
-      case 'connection' || 'disconnect':
+      case 'connection':
+      case 'disconnect':
         if (this.events[type]) {
           this.events[type].callbacks.forEach((cb) => {
             cb();

--- a/src/server/sender.ts
+++ b/src/server/sender.ts
@@ -1,0 +1,49 @@
+export default class Sender {
+  private messageQueue: any;
+  private ready: boolean;
+
+  constructor() {
+    this.messageQueue = [];
+    this.ready = true;
+  }
+
+  public add(message: any) {
+    this.messageQueue.push(message);
+    this.send();
+  }
+
+  public async invokeCallback(msgObj: any): Promise<void> {
+    const args = Array.prototype.slice.call(arguments);
+    for await (let cb of msgObj.callbacks) {
+      cb.apply(this, args);
+    }
+  }
+
+  private async send() {
+    if (this.ready && this.messageQueue.length) {
+      this.ready = false;
+      const messageObj = this.messageQueue.shift();
+      const {
+        type,
+        message,
+        from,
+        listeners
+      } = messageObj;
+      console.log(message);
+
+      const encodedMessage = new TextEncoder().encode(JSON.stringify({ [type]: message }));
+      for await (let listener of listeners) {
+        const [clientId, socketConn] = listener;
+        if (clientId !== from) {
+          try {
+            await socketConn.send(encodedMessage);
+          } catch (err) {
+            console.log(`Unable to send to client: ${clientId}`);
+          }
+        }
+      }
+      this.ready = true;
+      this.send();
+    }
+  }
+}

--- a/src/server/sender.ts
+++ b/src/server/sender.ts
@@ -29,7 +29,6 @@ export default class Sender {
         from,
         listeners
       } = messageObj;
-      console.log(message);
 
       const encodedMessage = new TextEncoder().encode(JSON.stringify({ [type]: message }));
       for await (let listener of listeners) {

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -7,22 +7,26 @@ import {
 import EventEmitter  from "./event_emitter.ts";
 
 export default class SocketServer extends EventEmitter {
-  protected configs: any;
+  private config: any;
 
-  constructor(configs: any = {}) {
+  constructor(config: any = {}) {
     super();
-    if (!configs.address) {
-      configs.address = "127.0.0.1";
+    if (!config.address) {
+      config.address = "127.0.0.1";
     }
-    if (!configs.port) {
-      configs.port = "3000";
+    if (!config.port) {
+      config.port = "3000";
     }
-    this.configs = configs;
+    this.config = config;
     this.connect();
   }
 
+  public getConfig() {
+    return this.config;
+  }
+
   public async connect() {
-    const server = serve(`${this.configs.address}:${this.configs.port}`);
+    const server = serve(`${this.config.address}:${this.config.port}`);
 
     for await (const req of server) {
       const { headers, conn } = req;

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -10,6 +10,7 @@ export {
 
 // Server
 import "./unit/server/event_emitter_test.ts";
+import "./unit/server/server_test.ts";
 
 // Client
 import "./unit/client/client_test.ts";

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -1,9 +1,4 @@
-Deno.env().DRASH_PROCESS = "test";
-
-import { runTests } from "../deps.ts";
 export {
-  test,
-  runTests,
   assertEquals,
   assert,
 } from "../deps.ts";
@@ -16,4 +11,4 @@ import "./unit/server/server_test.ts";
 import "./unit/client/client_test.ts";
 
 
-runTests();
+Deno.runTests();

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -6,6 +6,7 @@ export {
   runTests,
   assertEquals,
   assert,
+  assertThrows,
 } from "../deps.ts";
 
 // Server

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -6,7 +6,6 @@ export {
   runTests,
   assertEquals,
   assert,
-  assertThrows,
 } from "../deps.ts";
 
 // Server

--- a/tests/unit/client/client_test.ts
+++ b/tests/unit/client/client_test.ts
@@ -1,39 +1,39 @@
 import SocketClient from "../../../src/client/client.ts";
-import { test, assertEquals, assert } from "../../test.ts";
+import { test, assertEquals } from "../../test.ts";
 
 test("should connect to 3000 if port is not provided", () => {
-  const expect = 3000;
+  const expect = "3000";
   const client = new SocketClient();
   const clientOptions = client.getOptions();
   assertEquals(clientOptions.port, expect);
 });
 
 test("should connect to provided port", () => {
-  const expect = 3333;
-  const client = new SocketClient({ port: 3333 });
+  const expect = "3333";
+  const client = new SocketClient({ port: "3333" });
   const clientOptions = client.getOptions();
   assertEquals(clientOptions.port, expect);
 });
 
 test("should connect to 127.0.0.1 if address is not provided", () => {
   const expect = "127.0.0.1";
-  const client = new SocketClient({ port: 3333 });
+  const client = new SocketClient({ port: "3333" });
   const clientOptions = client.getOptions();
   assertEquals(clientOptions.address, expect);
 });
 
 test("should connect to provided address", () => {
   const expect = "1.1.1.1";
-  const client = new SocketClient({ address: "1.1.1.1", port: 3333 });
+  const client = new SocketClient({ address: "1.1.1.1", port: "3333" });
   const clientOptions = client.getOptions();
   assertEquals(clientOptions.address, expect);
 });
 
 test("should connect to provided address and port", () => {
-  const expect = { address:"1.1.1.1", port: 1111 };
+  const expect = { address:"1.1.1.1", port: "1111" };
   const client = new SocketClient({
     address:"1.1.1.1",
-    port: 1111,
+    port: "1111",
   });
   const clientOptions = client.getOptions();
   assertEquals(clientOptions, expect);

--- a/tests/unit/client/client_test.ts
+++ b/tests/unit/client/client_test.ts
@@ -1,35 +1,35 @@
 import SocketClient from "../../../src/client/client.ts";
-import { test, assertEquals } from "../../test.ts";
+import { assertEquals } from "../../test.ts";
 
-test("should connect to 3000 if port is not provided", () => {
+Deno.test("should connect to 3000 if port is not provided", () => {
   const expect = "3000";
   const client = new SocketClient();
   const clientOptions = client.getOptions();
   assertEquals(clientOptions.port, expect);
 });
 
-test("should connect to provided port", () => {
+Deno.test("should connect to provided port", () => {
   const expect = "3333";
   const client = new SocketClient({ port: "3333" });
   const clientOptions = client.getOptions();
   assertEquals(clientOptions.port, expect);
 });
 
-test("should connect to 127.0.0.1 if address is not provided", () => {
+Deno.test("should connect to 127.0.0.1 if address is not provided", () => {
   const expect = "127.0.0.1";
   const client = new SocketClient({ port: "3333" });
   const clientOptions = client.getOptions();
   assertEquals(clientOptions.address, expect);
 });
 
-test("should connect to provided address", () => {
+Deno.test("should connect to provided address", () => {
   const expect = "1.1.1.1";
   const client = new SocketClient({ address: "1.1.1.1", port: "3333" });
   const clientOptions = client.getOptions();
   assertEquals(clientOptions.address, expect);
 });
 
-test("should connect to provided address and port", () => {
+Deno.test("should connect to provided address and port", () => {
   const expect = { address:"1.1.1.1", port: "1111" };
   const client = new SocketClient({
     address:"1.1.1.1",

--- a/tests/unit/server/event_emitter_test.ts
+++ b/tests/unit/server/event_emitter_test.ts
@@ -3,7 +3,6 @@ import {
   test,
   assertEquals,
   assert,
-  assertThrows,
 } from "../../test.ts";
 
 let io = new EventEmitter();

--- a/tests/unit/server/event_emitter_test.ts
+++ b/tests/unit/server/event_emitter_test.ts
@@ -1,6 +1,5 @@
 import EventEmitter from "../../../src/server/event_emitter.ts";
 import {
-  test,
   assertEquals,
   assert,
 } from "../../test.ts";
@@ -14,12 +13,12 @@ const ClientSocket = () => {
   }
 };
 
-test("should have Events, Clients, and Sender on class init", () => {
+Deno.test("should have Events, Clients, and Sender on class init", () => {
   const expect = ['events', 'clients', 'sender'];
-  assert(expect.every((val) => io[val]));
+  assert(expect.every((val) => io.hasOwnProperty(val)));
 });
 
-test("should connect a client", () => {
+Deno.test("should connect a client", () => {
   const clientId = 1;
   const clientSocket = ClientSocket();
   io.addClient(clientSocket, clientId);
@@ -27,7 +26,7 @@ test("should connect a client", () => {
   assertEquals(connectedClients[clientId].socket, clientSocket);
 });
 
-test("should remove client", async () => {
+Deno.test("should remove client", async () => {
   const clientId = 1;
   const clientSocket = ClientSocket();
   await io.removeClient(clientId);
@@ -39,7 +38,7 @@ test("should remove client", async () => {
   assertEquals(connectedClients[newClientId].socket, clientSocket);
 });
 
-test("should add events for server to listen to", () => {
+Deno.test("should add events for server to listen to", () => {
   const expect = ['chat', 'room'];
   io.on('chat', () => true);
   io.on('room', () => true);
@@ -48,9 +47,9 @@ test("should add events for server to listen to", () => {
   assert(expect.every((val) => events[val]));
 });
 
-test("should detect same event name and push cb into callbacks array of event", () => {
+Deno.test("should detect same event name and push cb into callbacks array of event", () => {
   const expect = ['chat', 'room'];
-  io.on('chat', () => true);
+  io.on("chat", () => true);
 
   const events = io.getEvents();
   assert(expect.every((val) => events[val]));
@@ -58,8 +57,7 @@ test("should detect same event name and push cb into callbacks array of event", 
   assertEquals(events['chat'].callbacks.length, 2);
 });
 
-test("should register which clients are listening to what event", () => {
-  const expect = ['chat', 'room'];
+Deno.test("should register which clients are listening to what event", () => {
   io.addListener('chat', 2);
   const events = io.getEvents();
   assert(events['chat'].listeners.has(2));
@@ -71,7 +69,7 @@ test("should register which clients are listening to what event", () => {
   assertEquals(events['chat'].listeners.size, 2);
 });
 
-test("should remove client from events[type].listeners", async () => {
+Deno.test("should remove client from events[type].listeners", async () => {
   await io.removeClient(2);
   const clientsConnected = io.getClients();
   const events = io.getEvents();

--- a/tests/unit/server/event_emitter_test.ts
+++ b/tests/unit/server/event_emitter_test.ts
@@ -49,10 +49,6 @@ test("should add events for server to listen to", () => {
   assert(expect.every((val) => events[val]));
 });
 
-test("should throw an error if reserved event types are used", () => {
-  assertThrows(() => io.on('disconnect', () => true));
-});
-
 test("should detect same event name and push cb into callbacks array of event", () => {
   const expect = ['chat', 'room'];
   io.on('chat', () => true);

--- a/tests/unit/server/event_emitter_test.ts
+++ b/tests/unit/server/event_emitter_test.ts
@@ -1,5 +1,10 @@
 import EventEmitter from "../../../src/server/event_emitter.ts";
-import { test, assertEquals, assert } from "../../test.ts";
+import {
+  test,
+  assertEquals,
+  assert,
+  assertThrows,
+} from "../../test.ts";
 
 let io = new EventEmitter();
 
@@ -42,6 +47,10 @@ test("should add events for server to listen to", () => {
 
   const events = io.getEvents();
   assert(expect.every((val) => events[val]));
+});
+
+test("should throw an error if reserved event types are used", () => {
+  assertThrows(() => io.on('disconnect', () => true));
 });
 
 test("should detect same event name and push cb into callbacks array of event", () => {

--- a/tests/unit/server/server_test.ts
+++ b/tests/unit/server/server_test.ts
@@ -1,0 +1,42 @@
+import SocketServer from "../../../src/server/server.ts";
+import { test, assertEquals } from "../../test.ts";
+
+SocketServer.prototype.connect = (): Promise<void> => { return; };
+
+test("should connect to 3000 if port is not provided", () => {
+  const expect = "3000";
+  const server = new SocketServer();
+  const serverConfigs = server.getConfig();
+  assertEquals(serverConfigs.port, expect);
+});
+
+test("should connect to provided port", () => {
+  const expect = "3333";
+  const server = new SocketServer({ port: "3333" });
+  const serverConfigs = server.getConfig();
+  assertEquals(serverConfigs.port, expect);
+});
+
+test("should connect to 127.0.0.1 if address is not provided", () => {
+  const expect = "127.0.0.1";
+  const server = new SocketServer({ port: 3333 });
+  const serverConfigs = server.getConfig();
+  assertEquals(serverConfigs.address, expect);
+});
+
+test("should connect to provided address", () => {
+  const expect = "1.1.1.1";
+  const server = new SocketServer({ address: "1.1.1.1" });
+  const serverConfigs = server.getConfig();
+  assertEquals(serverConfigs.address, expect);
+});
+
+test("should connect to provided address and port", () => {
+  const expect = { address: "1.1.1.1", port: "1111" };
+  const server = new SocketServer({
+    address: "1.1.1.1",
+    port: "1111",
+  });
+  const serverConfigs = server.getConfig();
+  assertEquals(serverConfigs, expect);
+});

--- a/tests/unit/server/server_test.ts
+++ b/tests/unit/server/server_test.ts
@@ -1,37 +1,37 @@
 import SocketServer from "../../../src/server/server.ts";
-import { test, assertEquals } from "../../test.ts";
+import { assertEquals } from "../../test.ts";
 
-SocketServer.prototype.connect = (): Promise<void> => { return; };
+SocketServer.prototype.connect = (): Promise<void> => { return Promise.resolve(); };
 
-test("should connect to 3000 if port is not provided", () => {
+Deno.test("should connect to 3000 if port is not provided", () => {
   const expect = "3000";
   const server = new SocketServer();
   const serverConfigs = server.getConfig();
   assertEquals(serverConfigs.port, expect);
 });
 
-test("should connect to provided port", () => {
+Deno.test("should connect to provided port", () => {
   const expect = "3333";
   const server = new SocketServer({ port: "3333" });
   const serverConfigs = server.getConfig();
   assertEquals(serverConfigs.port, expect);
 });
 
-test("should connect to 127.0.0.1 if address is not provided", () => {
+Deno.test("should connect to 127.0.0.1 if address is not provided", () => {
   const expect = "127.0.0.1";
   const server = new SocketServer({ port: 3333 });
   const serverConfigs = server.getConfig();
   assertEquals(serverConfigs.address, expect);
 });
 
-test("should connect to provided address", () => {
+Deno.test("should connect to provided address", () => {
   const expect = "1.1.1.1";
   const server = new SocketServer({ address: "1.1.1.1" });
   const serverConfigs = server.getConfig();
   assertEquals(serverConfigs.address, expect);
 });
 
-test("should connect to provided address and port", () => {
+Deno.test("should connect to provided address and port", () => {
   const expect = { address: "1.1.1.1", port: "1111" };
   const server = new SocketServer({
     address: "1.1.1.1",


### PR DESCRIPTION
## What's included
This PR fulfills:
- (https://github.com/drashland/sockets/issues/7) There is a new file for `RESERVE_EVENT_TYPES`.  This might be overdoing it, but I thought that if we needed to reserve any other types and such, we can just build on it or remove it and just put it within the Class file.
- (https://github.com/drashland/sockets/issues/4) Tests have been added for `server/server.ts`. 
- Classes are now in separate files for better readability.
- Example of `io.on('connection', ...)` and `io.on('disconnect', ...)` are included in `example_app/console_app/`
- (https://github.com/drashland/sockets/issues/5) Upgraded to deno 0.34
