### PR TITLE
issue-#65-restrict-channel-access

### DIFF
--- a/src/transmitter.ts
+++ b/src/transmitter.ts
@@ -72,6 +72,14 @@ export class Transmitter {
       return this.handleReservedEvent(packet);
     }
 
+    // Don't allow clients to send messages to channels they aren't in
+    const channelsClientIsIn: string[] = Object.keys(this.server.channels).filter(channelName => {
+      return this.server.channels[channelName].listeners.has(Number(packet.from.id))
+    });
+    if (channelsClientIsIn.indexOf(packet.to) < 0) {
+      throw new Error(`Client ${packet.from.id} is not connected to ${packet.to}`)
+    }
+
     // Invoke all callbacks (aka the handlers for this packet)
     if (this.server.channels[packet.to]) {
       for await (let cb of this.server.channels[packet.to].callbacks) {


### PR DESCRIPTION
Fixes #65 

**Description**

Checks if the client is in the requested channel before handling the packet
If they are, then business as usual
If they aren't an error is thrown

**Other Notes**

I'm hesitant to add tests atm, of course i want to and i should, but with the tests PR (#67), the conflcits would just be a mess. Maybe this PR should be merged after, and i can add the tests (and pull) once the other PR is done and dusted?
