### PR TITLE
chore: Add github event on release to update sockets version in website

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,3 +14,7 @@ jobs:
           eggs upgrade
           eggs link ${{ secrets.CI_NESTLAND_API_KEY }}
           eggs publish
+
+      - name: Send Event to Website to Update Versions
+        run: |
+          curl -XPOST -u "${{ secrets.CI_USER_NAME }}:${{ secrets.CI_USER_PAT }}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" https://api.github.com/repos/drashland/website/dispatches --data '{"event_type": "update_docs", "client_payload": { "module_to_update": "sockets", "version": "${{ github.event.release.tag_name }}" }}'


### PR DESCRIPTION
**Description**

* On release, send GH event to website repo, to the sockets versions
