### PR TITLE
feat: Add message on channel close

### DIFF
--- a/src/event_emitter.ts
+++ b/src/event_emitter.ts
@@ -104,6 +104,9 @@ export class EventEmitter {
    * @param channelName - The name of the channel.
    */
   public closeChannel(channelName: string): void {
+    for (const client of Object.values(this.clients)) {
+      client.socket.send(`${channelName} closed.`);
+    }
     delete this.channels[channelName];
   }
 


### PR DESCRIPTION
Fixes #57 

**Description**

- Loop through all connected clients of the Channel to send the `{channel_name} closed.` message.
- Add the tests to ensure this works as expected.

**Other Notes**

- I'm not sure if the loop through all clients is the best way to do this (I'm having some doubts). If it is not, I hope you can guide me a bit on which is the best implementation for this.
